### PR TITLE
Missing add aggregation URL in menu bar fix

### DIFF
--- a/apiary.apib
+++ b/apiary.apib
@@ -4427,6 +4427,8 @@ List of aggregation source can be fetched using:
 + Response 404 (application/json)
 
     [1175][]
+
+
     
 ## Add [/aggregation/business/{businessId} {?api_key}]
 


### PR DESCRIPTION
@guptas Please merge this change. Added new line to show add aggregation url in side menu bar.